### PR TITLE
Fix overlap text and image on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3520,6 +3520,7 @@ background: radial-gradient(circle, rgba(76,165,179,1) 4%, rgba(43,22,79,1) 40%)
         bottom: 1px;
         background-position: center;
         width: 100%;
+        top: 50px;
   }
 }
  


### PR DESCRIPTION
This resolves issue #227 Image overlaps the title text [About Page] 1752e1f8e399d507f4b2bb4e247ffcd633fd59d7

![image](https://github.com/mgguild/msw-website/assets/42258463/a63652ae-f2b4-4e1a-8272-e0ebb093652a)
