### PR TITLE
FAQ Opensea mobile link fix

### DIFF
--- a/src/Components/Data/FAQs.ts
+++ b/src/Components/Data/FAQs.ts
@@ -15,7 +15,7 @@ export default [
   {
     question:
       'What is the official collection links for MetaSaga Warriors Genesis Collection?',
-    answer: 'https://opensea.io/collection/metasagawarriors',
+    answer: 'Visit our collections Here!',
   },
   {
     question: 'How do I store and manage my MetaSaga Warriors?',

--- a/src/Components/Pages/FAQ.tsx
+++ b/src/Components/Pages/FAQ.tsx
@@ -52,7 +52,8 @@ export default function App() {
                                     }}
                                 >
                                     {i === 3 ? (
-                                        <a
+                                        <a  
+                                            style={{ textDecoration: 'none' }}
                                             href="https://opensea.io/collection/metasagawarriors"
                                             target="_blank"
                                         >


### PR DESCRIPTION
Fix for issue #219 
Fixed overlapping text for opensea link 
![image](https://github.com/mgguild/msw-website/assets/57949551/f0d52b55-3555-4693-9518-7263a4f97296)
