### PR TITLE
Disable connect wallet button on bound wallet

### DIFF
--- a/src/Components/Modals/UserDashboard.tsx
+++ b/src/Components/Modals/UserDashboard.tsx
@@ -356,7 +356,7 @@ const UserDashboard = ({
                                             </Button>
                                         )}
                                     </Link>
-                                    <ConnectWallet theme={'dark'} modalSize={'wide'} />
+                                    {!_userTags.includes('title.D4F8F.BoundWallet') && <ConnectWallet theme={'dark'} modalSize={'wide'} />}
                                     <Button
                                         onClick={() => handleLogout()}
                                         borderRadius="8px"


### PR DESCRIPTION
Remove/Hide render of connect wallet button if user/player has a bound wallet account to avoid UI confusion